### PR TITLE
作ったページをレスポンシブ対応しよう

### DIFF
--- a/frontend/no.1/sample-app/components/atom/AuthorIcon.tsx
+++ b/frontend/no.1/sample-app/components/atom/AuthorIcon.tsx
@@ -12,13 +12,13 @@ export const AuthorIcon: VFC<Props> = ({ iconUrl, name }) => {
     <>
       <a href='#' className='flex items-center'>
         {/* Imageに直接layoutを指定しても動かないのでstyleをラップする https://stackoverflow.com/questions/65527407/next-image-not-taking-class-properties */}
-        <div className='mx-4 flex items-center'>
+        <div className='hidden mx-4 sm:flex items-center'>
           <Image
             src={iconUrl}
             alt='avator'
             width={40}
             height={40}
-            className='hidden object-cover w-10 h-10 rounded-full sm:block'
+            className='object-cover w-10 h-10 rounded-full sm:block'
           />
         </div>
         <p className='font-bold text-gray-700 hover:underline'>{name}</p>

--- a/frontend/no.1/sample-app/components/organism/layout/Header.tsx
+++ b/frontend/no.1/sample-app/components/organism/layout/Header.tsx
@@ -6,10 +6,20 @@ export const Header: VFC = () => {
       <nav className='px-6 py-4 bg-white border-gray-300 shadow'>
         <div className='container flex flex-col mx-auto md:flex-row md:items-center md:justify-between'>
           <div className='flex items-center justify-between'>
-            <a href='#' className='text-xl font-bold text-gray-800 md:text-2xl'>
-              Brand
-            </a>
+            <div>
+              <a href='#' className='text-xl font-bold text-gray-800 md:text-2xl'>
+                Brand
+              </a>
+            </div>
+            <div>
+              <button className='block text-gray-800 hover:text-gray-600 focus:text-gray-600 focus:outline-none md:hidden'>
+                <svg viewBox='0 0 24 24' className='w-6 h-6 fill-current'>
+                  <path d='M4 5h16a1 1 0 0 1 0 2H4a1 1 0 1 1 0-2zm0 6h16a1 1 0 0 1 0 2H4a1 1 0 0 1 0-2zm0 6h16a1 1 0 0 1 0 2H4a1 1 0 0 1 0-2z' />
+                </svg>
+              </button>
+            </div>
           </div>
+
           <div className='flex-col hidden md:flex md:flex-row md:-mx-4'>
             <a href='#' className='my-1 text-gray-800 hover:text-blue-500 md:mx-4 md:my-0'>
               Home

--- a/frontend/no.1/sample-app/components/template/Top.tsx
+++ b/frontend/no.1/sample-app/components/template/Top.tsx
@@ -51,6 +51,7 @@ export const Top: VFC<Props> = (props) => {
               <Pagenation totalPage={totalPage} currentPage={currentPage} />
             </div>
           </div>
+          {/* lg:block 1024px以上で表示 */}
           <div className='hidden w-4/12 -mx-8 lg:block'>
             <div className='px-8'>
               <h2 className='mb-4 text-xl font-bold text-gray-700'>Authors</h2>


### PR DESCRIPTION
## TL;DR
- iPhone Xの画面サイズに対応しました
- 前回の課題でブレークポイントを設定していたので、細かな修正だけになっています
- Tailwind responsive https://tailwindcss.com/docs/responsive-design
  - Tailwind便利だ...

## Description

| 実サイト | 実装  |
| ---- | ---- |
| <img width="311" alt="スクリーンショット 2021-12-29 4 06 32" src="https://user-images.githubusercontent.com/47236483/147599939-acd52c2a-ca3f-4626-a4e5-48395e8daf3c.png"> | <img width="307" alt="スクリーンショット 2021-12-29 4 06 53" src="https://user-images.githubusercontent.com/47236483/147599974-d209d0e0-e958-4024-81d9-428555f9ed78.png"> |
